### PR TITLE
移除多余逻辑判断。

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -122,7 +122,7 @@ class Container implements HyperfContainerInterface
     public function get($name)
     {
         // If the entry is already resolved we return it
-        if (isset($this->resolvedEntries[$name]) || array_key_exists($name, $this->resolvedEntries)) {
+        if (array_key_exists($name, $this->resolvedEntries)) {
             return $this->resolvedEntries[$name];
         }
         $this->resolvedEntries[$name] = $value = $this->make($name);


### PR DESCRIPTION
如果 `$this->resolvedEntries` 中存在要获取的 entry ，无论是否为 `null` 都返回的话，则不需要前面的 `isset` 判断。

如果 `$this->resolvedEntries` 中存在要获取的 entry ，但是为 `null` 不返回的话， 则不需要后面的 `array_key_exists` 的判断。
