### PR TITLE
phpunit进行单元测试时phpunit.xml文件中php的env变量无法转换的bug修复

### DIFF
--- a/src/Annotation/ScanConfig.php
+++ b/src/Annotation/ScanConfig.php
@@ -171,7 +171,7 @@ class ScanConfig
         if (file_exists($configDir . '/config.php')) {
             $configContent = include $configDir . '/config.php';
             $appEnv = $configContent['app_env'] ?? 'dev';
-            $cacheable = value($configContent['scan_cacheable'] ?? $appEnv === 'prod');
+            $cacheable = boolval($configContent['scan_cacheable'] ?? $appEnv === 'prod');
             if (isset($configContent['annotations'])) {
                 $config = static::allocateConfigValue($configContent['annotations'], $config);
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17948556/117524673-e8f03400-aff0-11eb-9348-97561d6a7b64.png)
